### PR TITLE
d4 Wrapper: use temporary file for binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,7 @@ dependencies = [
  "rug",
  "serial_test",
  "streaming-iterator",
+ "tempfile",
  "winapi",
  "workctl",
 ]
@@ -289,6 +290,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "file_diff"
@@ -884,6 +891,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "termtree"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ itertools = "0.11.0"
 once_cell = "1.18.0"
 bitvec = "1.0.1"
 streaming-iterator = "0.1.9"
+tempfile = "3.8.0"
 winapi = { version = "0.3.9", features = ["winnt"] }
 
 [dependencies.gmp-mpfr-sys]


### PR DESCRIPTION
This changes to `d4` wrapper to write the binary to a (random) temporary file, resolving the issue of not being able to run multiple instances in parallel.

Closes #3.