### PR TITLE
Enable static build without d4 on linux

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -4,7 +4,7 @@ on:
   - push
 
 jobs:
-  Test:
+  Check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -28,8 +28,16 @@ jobs:
           - triple: aarch64-apple-darwin
             runner: macos-latest
         variant:
-          - ''
-          - '-d4'
+          - flake: 'all'
+            artifact: ''
+          - flake: 'all-d4'
+            artifact: '-d4'
+        exclude:
+          - target: { triple: x86_64-unknown-linux-gnu, runner: ubuntu-latest }
+            variant: { flake: 'all', artifact: '' }
+        include:
+          - target: { triple: x86_64-unknown-linux-musl, runner: ubuntu-latest }
+            variant: { flake: 'ddnnife-static', artifact: '' }
     runs-on: ${{ matrix.target.runner }}
     steps:
       - name: Checkout
@@ -39,9 +47,9 @@ jobs:
       - name: Cache
         uses: DeterminateSystems/magic-nix-cache-action@v4
       - name: Build
-        run: nix build -L .#all${{ matrix.variant }}
+        run: nix build -L .#${{ matrix.variant.flake }}
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
-          name: ddnnife-${{ matrix.target.triple }}${{ matrix.variant }}
+          name: ddnnife-${{ matrix.target.triple }}${{ matrix.variant.artifact }}
           path: result

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ d4-oxide = { version = "0.3.0", optional = true }
 [dependencies.gmp-mpfr-sys]
 version = "1.6.1"
 default-features = false
-features = ["c-no-tests"]
+features = ["c-no-tests", "force-cross"]
 
 [dependencies.rug]
 version = "1.22.0"

--- a/flake.lock
+++ b/flake.lock
@@ -1,26 +1,5 @@
 {
   "nodes": {
-    "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1710886643,
-        "narHash": "sha256-saTZuv9YeZ9COHPuj8oedGdUwJZcbQ3vyRqe7NVJMsQ=",
-        "owner": "ipetkov",
-        "repo": "crane",
-        "rev": "5bace74e9a65165c918205cf67ad3977fe79c584",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ipetkov",
-        "ref": "v0.16.3",
-        "repo": "crane",
-        "type": "github"
-      }
-    },
     "d4": {
       "inputs": {
         "flake-utils": [
@@ -31,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1716292206,
-        "narHash": "sha256-0HuXLfmLF2kCcIEeud/pCg0oyZdqvI1ZthEYqe7+sM4=",
+        "lastModified": 1717150549,
+        "narHash": "sha256-xDXWnnXO1nLdW8fv9+59yvnSvTmfCOlsbPSyGcTEvwg=",
         "owner": "SoftVarE-Group",
         "repo": "d4v2",
-        "rev": "017defd368c9e4e24b881578e94ae53b5154f3fb",
+        "rev": "00f0e9fd785c422abf9b9e376830c4c9bb17819e",
         "type": "github"
       },
       "original": {
@@ -53,11 +32,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1716272846,
-        "narHash": "sha256-MtL0YhG20cngHsS6PIdpA3bkLnSx6XJBd2V8R9RaEc4=",
+        "lastModified": 1717223092,
+        "narHash": "sha256-ih8NPk3Jn5EAILOGQZ+KS5NLmu6QmwohJX+36MaTAQE=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "063d7e5fac454edd35b7e2cedb6ca9fb1410c79b",
+        "rev": "9a025daf6799e3af80b677f0af57ef76432c3fcf",
         "type": "github"
       },
       "original": {
@@ -84,23 +63,22 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716218643,
-        "narHash": "sha256-i/E7gzQybvcGAYDRGDl39WL6yVk30Je/NXypBz6/nmM=",
+        "lastModified": 1717144377,
+        "narHash": "sha256-F/TKWETwB5RaR8owkPPi+SPJh83AQsm6KrQAlJ8v/uA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a8695cbd09a7ecf3376bd62c798b9864d20f86ee",
+        "rev": "805a384895c696f802a9bf5bf4720f37385df547",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "crane": "crane",
         "d4": "d4",
         "fenix": "fenix",
         "flake-utils": "flake-utils",
@@ -110,11 +88,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1716107283,
-        "narHash": "sha256-NJgrwLiLGHDrCia5AeIvZUHUY7xYGVryee0/9D3Ir1I=",
+        "lastModified": 1717169693,
+        "narHash": "sha256-qBruki5NHrSqIw5ulxtwFmVsb6W/aOKOMjsCJjfalA4=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "21ec8f523812b88418b2bfc64240c62b3dd967bd",
+        "rev": "d6d735e6f20ef78b16a79886fe28bd69cf059504",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This makes some changes to the build system to build a static binary for Linux without d4.