### PR TITLE
Seperate t-wise configs by semicolon

### DIFF
--- a/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sampling_result.rs
+++ b/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sampling_result.rs
@@ -1,5 +1,5 @@
 use super::Sample;
-use crate::util::format_vec;
+use crate::util::format_vec_separated_by;
 use std::fmt;
 
 /// An abstraction over the result of sampling as it might be invalid or empty.
@@ -55,7 +55,9 @@ impl fmt::Display for SamplingResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SamplingResult::Empty | SamplingResult::Void => write!(f, ""),
-            SamplingResult::ResultWithSample(sample) => write!(f, "{}", format_vec(sample.iter())),
+            SamplingResult::ResultWithSample(sample) => {
+                write!(f, "{}", format_vec_separated_by(sample.iter(), ";"))
+            }
         }
     }
 }

--- a/ddnnife/src/util.rs
+++ b/ddnnife/src/util.rs
@@ -6,10 +6,17 @@ use rand::prelude::{SeedableRng, StdRng};
 #[cfg(not(any(feature = "deterministic", test)))]
 use rand::thread_rng;
 
-pub fn format_vec<T: ToString>(vals: impl Iterator<Item = T>) -> String {
+pub fn format_vec_separated_by<T: ToString>(
+    vals: impl Iterator<Item = T>,
+    separator: &str,
+) -> String {
     vals.map(|v| v.to_string())
         .collect::<Vec<String>>()
-        .join(" ")
+        .join(separator)
+}
+
+pub fn format_vec<T: ToString>(vals: impl Iterator<Item = T>) -> String {
+    format_vec_separated_by(vals, " ")
 }
 
 pub fn format_vec_vec<T>(vals: impl Iterator<Item = T>) -> String


### PR DESCRIPTION
Fixes #23.

This formats t-wise configs in stream mode the same way that random configs are formatted (by `;`).
