### PR TITLE
Enable the Kotlin Wrapper on musl Systems

### DIFF
--- a/.github/workflows/Kotlin.yaml
+++ b/.github/workflows/Kotlin.yaml
@@ -23,6 +23,20 @@ jobs:
             flake:
               kotlin: kotlin
               library: libddnnife
+          - standalone: true
+            suffix: -musl
+            double:
+              nix: aarch64-linux
+            runner: ubuntu-24.04-arm
+            flake:
+              kotlin: kotlin-musl
+          - standalone: true
+            suffix: -musl
+            double:
+              nix: x86_64-linux
+            runner: ubuntu-24.04
+            flake:
+              kotlin: kotlin-musl
           - double:
               nix: aarch64-darwin
               jvm: darwin-aarch64
@@ -58,15 +72,23 @@ jobs:
       - name: Build
         run: nix build -L .#${{ matrix.target.flake.kotlin }}
       - name: Export
+        if: ${{ !matrix.target.standalone }}
         run: |
           nix build -L .#${{ matrix.target.flake.library }}
           mkdir -p ${{ runner.temp }}/libddnnife
           cp -rL result/lib ${{ runner.temp }}/libddnnife/${{ matrix.target.double.jvm }}
       - name: Upload
+        if: ${{ !matrix.target.standalone }}
         uses: actions/upload-artifact@v7
         with:
           name: libddnnife-${{ matrix.target.double.nix }}
           path: ${{ runner.temp }}/libddnnife
+      - name: Upload
+        if: ${{ matrix.target.standalone }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ddnnife-kotlin-${{ matrix.target.double.nix }}${{ matrix.target.suffix }}
+          path: result
 
   Package:
     needs: Build

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
           pkgsStatic = pkgs.pkgsStatic;
           pkgsWindows = pkgs.pkgsCross.mingwW64;
           pkgsSelf = self.packages.${system};
+          pkgsMusl = pkgs.pkgsCross.musl64;
 
           rustAttrs = {
             inherit crane;
@@ -74,11 +75,21 @@
           ddnnife-windows = pkgsWindows.callPackage ./nix/ddnnife.nix defaultAttrs;
 
           libddnnife = pkgs.callPackage ./nix/ddnnife.nix libAttrs;
+          libddnnife-musl = pkgsMusl.callPackage ./nix/ddnnife.nix libAttrs;
           libddnnife-windows = pkgsWindows.callPackage ./nix/ddnnife.nix libAttrs;
 
           bindgen = pkgs.callPackage ./nix/bindgen.nix rustAttrs;
 
           kotlin = pkgs.callPackage ./nix/kotlin.nix kotlinAttrs;
+
+          kotlin-musl = pkgsMusl.callPackage ./nix/kotlin.nix (
+            kotlinAttrs
+            // {
+              libddnnife = pkgsSelf.libddnnife-musl;
+              ddnnife-kotlin = pkgsSelf.kotlin-musl;
+            }
+          );
+
           kotlin-windows = pkgsWindows.callPackage ./nix/kotlin.nix (
             kotlinAttrs
             // {

--- a/nix/ddnnife.nix
+++ b/nix/ddnnife.nix
@@ -31,6 +31,8 @@ let
 
   cc = if stdenv.targetPlatform.isWindows then cc-windows else stdenv.cc;
 
+  dynamicMusl = stdenv.targetPlatform.isMusl && !stdenv.targetPlatform.isStatic;
+
   target = stdenv.targetPlatform.rust.rustcTarget;
 
   toolchain =
@@ -125,6 +127,9 @@ craneLib.${craneAction} (
     cargoExtraArgs = lib.optionalString (component != null) "--package ${component}";
     cargoTestExtraArgs = cargoExtraArgs;
     cargoClippyExtraArgs = "--all-features -- --deny warnings";
+  }
+  // lib.optionalAttrs dynamicMusl {
+    CARGO_BUILD_RUSTFLAGS = "-C target-feature=-crt-static";
   }
   // lib.optionalAttrs benchmark {
     pname = "${name}-bench";


### PR DESCRIPTION
This adds musl libc builds of the library and Kotlin wrapper.

musl libraries cannot be bundled within the single Kotlin wrapper for all platforms as they would use the same path as the glibc libraries. Therefore, standalone Kotlin wrappers are built for musl.