### PR TITLE
Make t-wise Sampling Deterministic Between Runs

### DIFF
--- a/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample.rs
+++ b/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample.rs
@@ -1,11 +1,10 @@
-use crate::Ddnnf;
-use crate::ddnnf::anomalies::t_wise_sampling::sat_wrapper::SatWrapper;
-
 use super::Config;
 use super::t_iterator::TInteractionIter;
+use crate::Ddnnf;
+use crate::ddnnf::anomalies::t_wise_sampling::sat_wrapper::SatWrapper;
+use crate::int_hash::IntSet;
 use log::debug;
 use std::cmp::{Ordering, min};
-use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::iter;
 use std::num::ParseIntError;
@@ -22,7 +21,7 @@ pub struct Sample {
     /// Configs that do not contain all variables of this sample
     pub partial_configs: Vec<Config>,
     /// The variables that Configs of this sample may contain
-    pub vars: HashSet<u32>,
+    pub vars: IntSet<u32>,
     /// The literals that actually occur in this sample, this is not a HashSet because we want
     /// a stable iteration order.
     pub literals: Vec<i32>,
@@ -66,7 +65,7 @@ impl Display for Sample {
 
 impl Sample {
     /// Create an empty sample that may contain the given variables
-    pub fn new(vars: HashSet<u32>) -> Self {
+    pub fn new(vars: IntSet<u32>) -> Self {
         Self {
             complete_configs: vec![],
             partial_configs: vec![],
@@ -99,7 +98,7 @@ impl Sample {
         literals.sort_unstable();
         literals.dedup();
 
-        let vars: HashSet<u32> = literals.iter().map(|x| x.unsigned_abs()).collect();
+        let vars: IntSet<u32> = literals.iter().map(|x| x.unsigned_abs()).collect();
 
         let mut sample = Self {
             complete_configs: vec![],
@@ -113,13 +112,13 @@ impl Sample {
     }
 
     pub fn new_from_samples(samples: &[&Self]) -> Self {
-        let vars: HashSet<u32> = samples
+        let vars: IntSet<u32> = samples
             .iter()
             .flat_map(|sample| sample.vars.iter())
             .cloned()
             .collect();
 
-        let literals: HashSet<i32> = samples
+        let literals: IntSet<i32> = samples
             .iter()
             .flat_map(|sample| sample.get_literals().iter().copied())
             .collect();
@@ -132,7 +131,7 @@ impl Sample {
 
     /// Create a sample that only contains a single configuration with a single literal
     pub fn from_literal(literal: i32, number_of_variables: usize) -> Self {
-        let mut sample = Self::new(HashSet::from([literal.unsigned_abs()]));
+        let mut sample = Self::new([literal.unsigned_abs()].into_iter().collect());
         sample.literals = vec![literal];
         sample.add_complete(Config::from(&[literal], number_of_variables));
         sample
@@ -147,14 +146,14 @@ impl Sample {
             .collect::<Result<Vec<Config>, ParseIntError>>()?;
 
         // Collect the literals in all configurations.
-        let literals: HashSet<i32> = configs
+        let literals: IntSet<i32> = configs
             .iter()
             .flat_map(|config| config.literals.iter())
             .copied()
             .collect();
 
         // Collect the corresponding variables.
-        let vars: HashSet<u32> = literals
+        let vars: IntSet<u32> = literals
             .iter()
             .map(|literal| literal.unsigned_abs())
             .collect();
@@ -184,7 +183,7 @@ impl Sample {
         &self.literals
     }
 
-    pub fn get_vars(&self) -> &HashSet<u32> {
+    pub fn get_vars(&self) -> &IntSet<u32> {
         &self.vars
     }
 
@@ -216,10 +215,9 @@ impl Sample {
     ///
     /// # Examples
     /// ```
-    /// use std::collections::HashSet;
     /// use ddnnife::ddnnf::anomalies::t_wise_sampling::{Config, Sample};
     ///
-    /// let sample = Sample::new(HashSet::from([1,2,3]));
+    /// let sample = Sample::new([1,2,3].into_iter().collect());
     ///
     /// assert!(sample.is_config_complete(&Config::from(&[1,2,3], 3)));
     /// assert!(!sample.is_config_complete(&Config::from(&[1,2], 3)));
@@ -258,9 +256,8 @@ impl Sample {
     ///
     /// # Examples
     /// ```
-    /// use std::collections::HashSet;
     /// use ddnnife::ddnnf::anomalies::t_wise_sampling::{Config, Sample};
-    /// let mut s = Sample::new(HashSet::from([1,2,3]));
+    /// let mut s = Sample::new([1,2,3].into_iter().collect());
     ///
     /// assert!(s.is_empty());
     /// s.add_partial(Config::from(&[1,3], 3));
@@ -359,7 +356,7 @@ mod test {
         let sample = Sample {
             complete_configs: vec![Config::from(&[1, 2, 3, -4, -5], 5)],
             partial_configs: vec![],
-            vars: HashSet::from([1, 2, 3, 4, 5]),
+            vars: [1, 2, 3, 4, 5].into_iter().collect(),
             literals: vec![1, 2, 3, -4, -5],
         };
 

--- a/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample_merger/similarity_merger.rs
+++ b/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample_merger/similarity_merger.rs
@@ -2,10 +2,10 @@ use super::super::SamplingResult;
 use super::super::t_iterator::TInteractionIter;
 use super::{Config, Sample};
 use super::{OrMerger, SampleMerger};
+use crate::int_hash::IntSet;
 use crate::util::rng;
 use rand::prelude::SliceRandom;
 use std::cmp::{Ordering, min};
-use std::collections::HashSet;
 use streaming_iterator::StreamingIterator;
 
 #[derive(Debug, Copy, Clone)]
@@ -74,7 +74,7 @@ fn snd<'a>((_, candidate): &(usize, &'a Candidate<'_>)) -> &'a Candidate<'a> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct Candidate<'a> {
     config: &'a Config,
-    literals: HashSet<i32>,
+    literals: IntSet<i32>,
     max_intersect: usize,
     total_intersect: usize,
 }
@@ -101,7 +101,7 @@ impl Ord for Candidate<'_> {
 
 impl<'a> Candidate<'a> {
     fn new(config: &'a Config) -> Self {
-        let literals: HashSet<i32> = config.get_decided_literals().collect();
+        let literals: IntSet<i32> = config.get_decided_literals().collect();
         debug_assert!(!literals.contains(&0));
         debug_assert!(!literals.is_empty());
         Self {
@@ -112,7 +112,7 @@ impl<'a> Candidate<'a> {
         }
     }
 
-    fn update(&mut self, other_literals: &HashSet<i32>) {
+    fn update(&mut self, other_literals: &IntSet<i32>) {
         let intersect = self.literals.intersection(other_literals).count();
 
         self.total_intersect += intersect;
@@ -180,7 +180,7 @@ mod test {
 
         sample
             .iter()
-            .for_each(|c| candidate.update(&c.get_decided_literals().collect()));
+            .for_each(|c| candidate.update(&c.get_decided_literals().collect::<IntSet<_>>()));
 
         assert!(candidate.is_t_wise_covered_by(&sample, 2));
 
@@ -193,7 +193,7 @@ mod test {
 
         sample
             .iter()
-            .for_each(|c| candidate.update(&c.get_decided_literals().collect()));
+            .for_each(|c| candidate.update(&c.get_decided_literals().collect::<IntSet<_>>()));
 
         assert!(!candidate.is_t_wise_covered_by(&sample, 2));
     }

--- a/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample_merger/zipping_merger.rs
+++ b/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample_merger/zipping_merger.rs
@@ -70,7 +70,7 @@ impl SampleMerger for ZippingMerger<'_> {
 
 impl ZippingMerger<'_> {
     /// Generates all t-wise interactions between two samples.
-    fn interactions(left: &Sample, right: &Sample, t: usize) -> HashSet<Vec<i32>> {
+    fn interactions(left: &Sample, right: &Sample, t: usize) -> Vec<Vec<i32>> {
         Self::generate_interactions(
             Self::generate_self_interactions(left, t),
             Self::generate_self_interactions(right, t),
@@ -83,7 +83,7 @@ impl ZippingMerger<'_> {
     fn generate_interactions(
         left: impl Iterator<Item = HashSet<Vec<i32>>>,
         right: impl DoubleEndedIterator<Item = HashSet<Vec<i32>>>,
-    ) -> HashSet<Vec<i32>> {
+    ) -> Vec<Vec<i32>> {
         let mut interactions = HashSet::new();
 
         // Both sets are sorted from 1 to t-1.
@@ -94,12 +94,29 @@ impl ZippingMerger<'_> {
                 for right in &right {
                     let mut interaction = left.clone();
                     interaction.extend_from_slice(right);
+                    interaction.sort_unstable();
                     interactions.insert(interaction);
                 }
             }
         });
 
-        interactions
+        // Deterministic sampling requires the same iteration order between runs.
+        // As the HashSets used for the rest of the algorithm do not provide such a determinsitic order,
+        // we collect, sort and (determinsitically) shuffle the generated interactions.
+        #[cfg(feature = "deterministic")]
+        {
+            use crate::util::rng;
+            use rand::seq::SliceRandom;
+
+            let mut interactions: Vec<Vec<i32>> = interactions.into_iter().collect();
+            interactions.sort_unstable();
+            interactions.shuffle(&mut rng());
+
+            interactions
+        }
+
+        #[cfg(not(feature = "deterministic"))]
+        interactions.into_iter().collect()
     }
 
     /// Generates a set of interactions inside a sample ordered by interactions size.
@@ -177,7 +194,7 @@ mod test {
     use crate::parser::build_ddnnf;
 
     use super::*;
-    use std::collections::HashSet;
+    use crate::int_hash::IntSet;
     use std::path::Path;
 
     #[test]
@@ -198,7 +215,7 @@ mod test {
     /// Create an empty sample that may contain the given variables and will certainly contain
     /// the given literals. Only use this if you know that the configs you are going to add to
     /// this sample contain the given literals.
-    fn new_with_literals(vars: HashSet<u32>, mut literals: Vec<i32>) -> Sample {
+    fn new_with_literals(vars: IntSet<u32>, mut literals: Vec<i32>) -> Sample {
         literals.sort_unstable();
         literals.dedup();
         Sample {
@@ -221,7 +238,7 @@ mod test {
             ddnnf: &ddnnf,
         };
 
-        let mut left_sample = new_with_literals(HashSet::from([2, 3]), vec![-2, 3]);
+        let mut left_sample = new_with_literals([2, 3].into_iter().collect(), vec![-2, 3]);
         left_sample.add_partial(Config::from(&[3, -2], 4));
         let right_sample = Sample::new_from_configs(vec![Config::from(&[1, 4], 4)]);
 

--- a/ddnnife/src/ddnnf/anomalies/t_wise_sampling/t_wise_sampler.rs
+++ b/ddnnife/src/ddnnf/anomalies/t_wise_sampling/t_wise_sampler.rs
@@ -4,19 +4,19 @@ use super::t_iterator::TInteractionIter;
 use super::{Sample, SamplingResult, SatWrapper};
 use crate::NodeType;
 use crate::ddnnf::extended_ddnnf::ExtendedDdnnf;
+use crate::int_hash::{self, IntMap, IntSet};
 use crate::util::rng;
 use crate::{Ddnnf, DdnnfKind};
 use itertools::Itertools;
 use rand::prelude::SliceRandom;
 use std::cmp::min;
-use std::collections::{HashMap, HashSet};
 use streaming_iterator::StreamingIterator;
 
 pub struct TWiseSampler<'a, A: AndMerger, O: OrMerger> {
     /// The d-DNNF to sample.
     pub(crate) ddnnf: &'a Ddnnf,
     /// Map that holds the [SamplingResult]s for the nodes.
-    pub(crate) partial_samples: HashMap<usize, SamplingResult>,
+    pub(crate) partial_samples: IntMap<usize, SamplingResult>,
     /// The merger for and nodes.
     and_merger: A,
     /// The merger for or nodes.
@@ -28,7 +28,7 @@ impl<'a, A: AndMerger, O: OrMerger> TWiseSampler<'a, A, O> {
     pub fn new(ddnnf: &'a Ddnnf, and_merger: A, or_merger: O) -> Self {
         Self {
             ddnnf,
-            partial_samples: HashMap::with_capacity(ddnnf.nodes.len()),
+            partial_samples: int_hash::map_with_capacity(ddnnf.nodes.len()),
             and_merger,
             or_merger,
         }
@@ -259,8 +259,8 @@ pub fn trim_and_resample(
 }
 
 #[inline]
-fn trim_sample(sample: &Sample, ranks: &[f64], avg_rank: f64) -> (Sample, HashSet<i32>) {
-    let mut literals_to_resample: HashSet<i32> = HashSet::new();
+fn trim_sample(sample: &Sample, ranks: &[f64], avg_rank: f64) -> (Sample, IntSet<i32>) {
+    let mut literals_to_resample: IntSet<i32> = IntSet::default();
     let mut new_sample = Sample::new_from_samples(&[sample]);
     let complete_len = sample.complete_configs.len();
 

--- a/ddnnife/src/int_hash.rs
+++ b/ddnnife/src/int_hash.rs
@@ -1,0 +1,130 @@
+use std::collections::{HashMap, HashSet};
+use std::hash::{BuildHasher, Hash, Hasher};
+
+/// Creates a new `IntMap` with capacity reserved for the given number of elements.
+pub fn map_with_capacity<K, V>(capacity: usize) -> IntMap<K, V>
+where
+    K: Hash + Eq,
+{
+    let mut map = IntMap::default();
+    map.reserve(capacity);
+    map
+}
+
+/// A `HashMap` not doing any hashing but using keys as-is.
+pub type IntMap<K, V> = HashMap<K, V, BuildIntHasher>;
+
+/// A `HashSet` not doing any hashing but using keys as-is.
+pub type IntSet<K> = HashSet<K, BuildIntHasher>;
+
+/// A hasher for integer maps and sets.
+///
+/// Does not do any hashing but instead returns input values as-is.
+/// Currently only accepts `usize`, `u32` and `i32`.
+#[derive(Default)]
+pub struct IntHasher {
+    hash: u64,
+}
+
+impl Hasher for IntHasher {
+    fn write(&mut self, _bytes: &[u8]) {
+        panic!("IntHasher only takes usize, u32 and i32 inputs");
+    }
+
+    fn write_usize(&mut self, input: usize) {
+        self.hash = input as u64;
+    }
+
+    fn write_u32(&mut self, input: u32) {
+        self.hash = input as u64;
+    }
+
+    fn write_i32(&mut self, input: i32) {
+        self.hash = input as u64;
+    }
+
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+}
+
+/// A builder for `IntHasher`.
+#[derive(Default, Clone, Copy)]
+pub struct BuildIntHasher;
+
+impl BuildHasher for BuildIntHasher {
+    type Hasher = IntHasher;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        IntHasher::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IntHasher, IntMap, IntSet};
+    use std::hash::{Hash, Hasher};
+
+    #[test]
+    fn deterministic_same() {
+        let mut hasher1 = IntHasher::default();
+        42.hash(&mut hasher1);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = IntHasher::default();
+        42.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_eq!(hash1, hash2, "Same input must produce same hash");
+    }
+
+    #[test]
+    fn deterministic_not_same() {
+        let mut hasher1 = IntHasher::default();
+        1.hash(&mut hasher1);
+        let hash1 = hasher1.finish();
+
+        let mut hasher2 = IntHasher::default();
+        42.hash(&mut hasher2);
+        let hash2 = hasher2.finish();
+
+        assert_ne!(
+            hash1, hash2,
+            "Different inputs must produce different hashes"
+        );
+    }
+
+    #[test]
+    fn map_get() {
+        let mut map = IntMap::default();
+        map.insert(42, "answer");
+        assert_eq!(map.get(&42), Some(&"answer"));
+        assert_eq!(map.get(&0), None);
+    }
+
+    #[test]
+    fn set_contains() {
+        let mut set = IntSet::default();
+        set.insert(42);
+        assert!(set.contains(&42));
+        assert!(!set.contains(&0));
+    }
+
+    #[test]
+    fn set_deterministic_iteration() {
+        let mut a = IntSet::default();
+        a.insert(3);
+        a.insert(1);
+        a.insert(2);
+
+        let mut b = IntSet::default();
+        b.insert(3);
+        b.insert(1);
+        b.insert(2);
+
+        let a_vec: Vec<i32> = a.into_iter().collect();
+        let b_vec: Vec<i32> = b.into_iter().collect();
+
+        assert_eq!(a_vec, b_vec);
+    }
+}

--- a/ddnnife/src/lib.rs
+++ b/ddnnife/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod int_hash;
 pub mod parser;
 pub mod util;
 pub use crate::parser::c2d_lexer;

--- a/ddnnife_ffi/src/t_wise_sampling.rs
+++ b/ddnnife_ffi/src/t_wise_sampling.rs
@@ -1,6 +1,6 @@
 use crate::ddnnf::Ddnnf;
 use ddnnife::ddnnf::anomalies::t_wise_sampling;
-use std::collections::HashSet;
+use ddnnife::int_hash::IntSet;
 
 #[uniffi::export]
 impl Ddnnf {
@@ -28,7 +28,7 @@ pub struct Sample {
     /// Configs that do not contain all variables of this sample
     pub partial_configs: Vec<Config>,
     /// The variables that Configs of this sample may contain
-    pub vars: HashSet<u32>,
+    pub vars: IntSet<u32>,
     /// The literals that actually occur in this sample
     pub literals: Vec<i32>,
 }

--- a/ddnnife_ffi/src/types.rs
+++ b/ddnnife_ffi/src/types.rs
@@ -1,3 +1,4 @@
+use ddnnife::int_hash::IntSet;
 use num::BigInt;
 use std::collections::HashSet;
 
@@ -19,9 +20,9 @@ uniffi::custom_type!(BigInt, Vec<u8>, {
     try_lift: |vec| Ok(BigInt::from_signed_bytes_be(&vec)),
 });
 
-type HashSetu32 = HashSet<u32>;
+type IntSetu32 = IntSet<u32>;
 
-uniffi::custom_type!(HashSetu32, Vec<u32>, {
+uniffi::custom_type!(IntSetu32, Vec<u32>, {
     remote,
     lower: |hashset| hashset.into_iter().collect(),
     try_lift: |vec| Ok(vec.into_iter().collect()),

--- a/ddnnife_ffi/uniffi.toml
+++ b/ddnnife_ffi/uniffi.toml
@@ -14,7 +14,7 @@ from_custom = "{}.toByteArray()"
 into_custom = "int.from_bytes({}, 'big')"
 from_custom = "{}.to_bytes()"
 
-[bindings.kotlin.custom_types.HashSetu32]
+[bindings.kotlin.custom_types.IntSetu32]
 type_name = "HashSet<UInt>"
 into_custom = "HashSet({})"
 from_custom = "{}.toList()"


### PR DESCRIPTION
Enables better testing and reasoning of the t-wise implementation.

Introduces `IntSet` and `IntMap` for deterministic iteration order.