### PR TITLE
Add t-wise Checking Functionality

### DIFF
--- a/ddnnife/src/ddnnf/anomalies/t_wise_sampling/config.rs
+++ b/ddnnife/src/ddnnf/anomalies/t_wise_sampling/config.rs
@@ -1,9 +1,10 @@
 use super::SatWrapper;
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
+use std::num::ParseIntError;
 
 /// Represents a (partial) configuration
-#[derive(Debug, Clone, Eq)]
+#[derive(Debug, Clone, Eq, Default)]
 pub struct Config {
     /// A vector of selected features (positive values) and deselected features (negative values)
     pub literals: Vec<i32>,
@@ -31,6 +32,15 @@ impl Extend<i32> for Config {
         self.sat_state_complete = false;
         for literal in iter {
             self.add(literal);
+        }
+    }
+}
+
+impl FromIterator<i32> for Config {
+    fn from_iter<T: IntoIterator<Item = i32>>(iter: T) -> Self {
+        Self {
+            literals: iter.into_iter().collect(),
+            ..Default::default()
         }
     }
 }
@@ -65,6 +75,16 @@ impl Config {
         };
         config.extend(literals.iter().copied());
         config
+    }
+
+    /// Parses a configuration from a line of whitespace-separated literals.
+    pub fn from_str(input: &str, number_of_variables: usize) -> Result<Self, ParseIntError> {
+        let literals = input
+            .split_ascii_whitespace()
+            .map(|literal| literal.parse())
+            .collect::<Result<Vec<i32>, ParseIntError>>()?;
+
+        Ok(Self::from(&literals, number_of_variables))
     }
 
     /// Creates a new config from two disjoint configs.

--- a/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample.rs
+++ b/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample.rs
@@ -1,9 +1,14 @@
+use crate::Ddnnf;
+use crate::ddnnf::anomalies::t_wise_sampling::sat_wrapper::SatWrapper;
+
 use super::Config;
 use super::t_iterator::TInteractionIter;
+use log::debug;
 use std::cmp::{Ordering, min};
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::iter;
+use std::num::ParseIntError;
 use streaming_iterator::StreamingIterator;
 
 /// Represents a (partial) sample of configs.
@@ -133,6 +138,48 @@ impl Sample {
         sample
     }
 
+    /// Creates a new sample from a set of lines representing a configuration each.
+    pub fn from_str(input: &str, number_of_variables: usize) -> Result<Self, ParseIntError> {
+        // Transform each line into a configuration.
+        let configs: Vec<Config> = input
+            .lines()
+            .map(|line| Config::from_str(line, number_of_variables))
+            .collect::<Result<Vec<Config>, ParseIntError>>()?;
+
+        // Collect the literals in all configurations.
+        let literals: HashSet<i32> = configs
+            .iter()
+            .flat_map(|config| config.literals.iter())
+            .copied()
+            .collect();
+
+        // Collect the corresponding variables.
+        let vars: HashSet<u32> = literals
+            .iter()
+            .map(|literal| literal.unsigned_abs())
+            .collect();
+
+        // Split the complete and partial configurations.
+        let mut complete_configs = Vec::new();
+        let mut partial_configs = Vec::new();
+
+        configs.into_iter().for_each(|config| {
+            if config.is_complete() {
+                complete_configs.push(config);
+                return;
+            }
+
+            partial_configs.push(config);
+        });
+
+        Ok(Self {
+            complete_configs,
+            partial_configs,
+            vars,
+            literals: literals.into_iter().collect(),
+        })
+    }
+
     pub fn get_literals(&self) -> &[i32] {
         &self.literals
     }
@@ -235,6 +282,71 @@ impl Sample {
 
         TInteractionIter::new(&literals, min(t, literals.len()))
             .all(|interaction| self.covers(interaction))
+    }
+
+    /// Checks whether all configurations of this sample are complete, i.e. the number
+    /// of literals they contain is the same as the number of variables in this sample
+    /// overall.
+    pub fn all_complete(&self) -> bool {
+        self.iter().all(|config| config.is_complete())
+    }
+
+    /// Checks whether all configurations in this sample are SAT.
+    pub fn all_sat(&self, ddnnf: &Ddnnf) -> bool {
+        let sat = SatWrapper::new(ddnnf);
+
+        // Consider each config.
+        self.iter().all(|config| {
+            // Create a mutable clone for checking SAT.
+            let mut config = config.clone();
+            let literals: Vec<i32> = config.get_decided_literals().collect();
+
+            if config.sat_state.is_none() {
+                config.set_sat_state(sat.new_state());
+            }
+
+            // Check that the config is SAT.
+            sat.is_sat_cached(
+                &literals,
+                config
+                    .get_sat_state()
+                    .expect("sat_state should exist because we initialized it a few lines before"),
+            )
+        })
+    }
+
+    /// Checks whether this sample covers all SAT t-wise interactions of the given literals.
+    pub fn covers_literals(&self, ddnnf: &Ddnnf, literals: &[i32], t: usize) -> bool {
+        let sat = SatWrapper::new(ddnnf);
+
+        // Keep track of how many actually vaild interactions are checked.
+        let mut count = 0;
+
+        // Generate all possible t-wise interactions between the given literals.
+        let result = TInteractionIter::new(literals, t)
+            // Only consier those that are actually valid (SAT).
+            .filter(|interaction| sat.is_sat_cached(interaction, &mut sat.new_state()))
+            .inspect(|_| count += 1)
+            // Check that each is covered by this sample.
+            .all(|interaction| self.covers(interaction));
+
+        debug!("Checked {count} interactions.");
+
+        result
+    }
+
+    /// Checks whether this sample covers all SAT t-wise interactions of the given variables.
+    pub fn covers_variables(&self, ddnnf: &Ddnnf, variables: &[u32], t: usize) -> bool {
+        // Generate both polarities of each variable.
+        // Interactions will be later filtered on whether they are SAT.
+        let literals: Vec<i32> = variables
+            .iter()
+            .map(|&variable| variable as i32)
+            .flat_map(|variable| [variable, -variable].into_iter())
+            .collect();
+
+        // Check the generated literals.
+        self.covers_literals(ddnnf, &literals, t)
     }
 }
 

--- a/ddnnife_cli/src/main.rs
+++ b/ddnnife_cli/src/main.rs
@@ -4,13 +4,14 @@ use crate::stream::{Query, handle_query, stream};
 use clap::{Parser, Subcommand};
 use ddnnife::DdnnfKind;
 use ddnnife::ddnnf::Ddnnf;
+use ddnnife::ddnnf::anomalies::t_wise_sampling::Sample;
 use ddnnife::ddnnf::statistics::Statistics;
 use ddnnife::parser::{self as dparser, persisting::write_as_mermaid_md};
 use ddnnife::util::format_vec;
 use ddnnife_cnf::Cnf;
 use log::info;
-use std::fs::File;
-use std::io::{self, BufRead, BufReader, BufWriter, Error, Write, stdout};
+use std::fs::{self, File};
+use std::io::{self, BufRead, BufReader, BufWriter, Error, ErrorKind, Write, stdout};
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
@@ -119,6 +120,27 @@ enum Operation {
         /// but also the larger the number of test cases required.
         #[clap(short, default_value_t = 2)]
         t: usize,
+    },
+    /// Checks a t-wise sample for validity.
+    TWiseCheck {
+        /// Path to the sample file to check.
+        sample: PathBuf,
+        /// `t` value for checking whether all interactions of a given set of literals or variables
+        /// is covered.
+        #[clap(short, default_value_t = 2)]
+        t: usize,
+        /// When present, it is checked whether the sample covers all t-wise interactions between
+        /// the given literals.
+        ///
+        /// Multiple values are delimited by `,`.
+        #[clap(short, long, allow_negative_numbers = true, value_delimiter = ',')]
+        literals: Option<Vec<i32>>,
+        /// When present, it is checked whether the sample covers all t-wise interactions between
+        /// the given variables.
+        ///
+        /// Multiple values are delimited by `,`.
+        #[clap(short, long, value_delimiter = ',')]
+        variables: Option<Vec<u32>>,
     },
     /// Computes core, dead, false-optional features, and atomic sets.
     Anomalies,
@@ -261,6 +283,48 @@ fn main() -> io::Result<()> {
             }
             Operation::TWise { t } => {
                 writer.write_all(ddnnf.sample_t_wise(*t).to_string().as_bytes())?;
+            }
+            Operation::TWiseCheck {
+                sample,
+                t,
+                literals,
+                variables,
+            } => {
+                let sample = Sample::from_str(
+                    &fs::read_to_string(sample)?,
+                    ddnnf.number_of_variables as usize,
+                )
+                .map_err(|error| Error::new(ErrorKind::InvalidData, error.to_string()))?;
+
+                if !sample.all_complete() {
+                    return Err(Error::other("Some configurations are incomplete."));
+                }
+
+                info!("All configurations are complete.");
+
+                if !sample.all_sat(&ddnnf) {
+                    return Err(Error::other("Some configurations are UNSAT."));
+                }
+
+                info!("All configurations are SAT.");
+
+                if let Some(literals) = literals {
+                    if !sample.covers_literals(&ddnnf, literals, *t) {
+                        return Err(Error::other("Some literals are not covered."));
+                    }
+
+                    info!("All literals are covered.");
+                }
+
+                if let Some(variables) = variables {
+                    if !sample.covers_variables(&ddnnf, variables, *t) {
+                        return Err(Error::other("Some variables are not covered."));
+                    }
+
+                    info!("All variables are covered.");
+                }
+
+                return Ok(());
             }
             // computes the cardinality for the partial configuration that can be mentioned with parameters
             Operation::Count { features } => {


### PR DESCRIPTION
Adds a command `t-wise-check` for inspecting a sample that:

- checks all configurations are complete
- checks all configurations are SAT
- optionally checks that a given set of literals or variables is covered