### PR TITLE
Make Determinism a Runtime Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,21 @@ If no candidates are supplied, all features of the d-DNNF will be the candidates
 atomic v 1 2 3 4 5 6 7 8 9 10 a 1
 ```
 
+## Determinism
+
+> [!IMPORTANT]
+> The random number generator used by ddnnife is **not** cryptographically safe.
+
+ddnnife makes use of randomness for some of its algorithms.
+Specifically, the following calculations include potentially multiple calls to random number generators:
+
+- t-wise sampling
+- uniform random sampling
+
+Currently, it is possible to seed the random number generation used for t-wise sampling (**not** uniform random sampling).
+This can be done on the CLI via the `--seed` option.
+Specifying a seed will make the operation deterministic while not providing one will result in a pseudorandom operation.
+
 [crate]: https://crates.io/crates/ddnnife
 [pypi]: https://pypi.org/project/ddnnife
 [releases]: https://github.com/SoftVarE-Group/d-dnnf-reasoner/releases

--- a/ddnnife/Cargo.toml
+++ b/ddnnife/Cargo.toml
@@ -7,9 +7,6 @@ edition = "2024"
 license = "LGPL-3.0-or-later"
 workspace = ".."
 
-[features]
-deterministic = []
-
 [dependencies]
 bimap = "0.6"
 bitvec = "1"

--- a/ddnnife/src/config.rs
+++ b/ddnnife/src/config.rs
@@ -1,0 +1,61 @@
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Global flag to control deterministic behavior at runtime.
+///
+/// Defaults to `false`, meaning ddnnife will use non-deterministic operations.
+#[cfg(not(test))]
+static DETERMINISTIC: AtomicBool = AtomicBool::new(false);
+
+#[cfg(test)]
+static DETERMINISTIC: AtomicBool = AtomicBool::new(true);
+
+/// Global value for seeding random number generators.
+///
+/// Only has an effect when [DETERMINISTIC] is `true`.
+static DETERMINISTIC_SEED: OnceLock<u64> = OnceLock::new();
+
+/// Enables or disables deterministic operations.
+///
+/// Actually using deterministic operations requires a seed to be set.
+/// See [set_seed].
+#[inline]
+pub fn set_deterministic(enable: bool) {
+    DETERMINISTIC.store(enable, Ordering::Relaxed);
+}
+
+/// Returns whether deterministic mode is currently enabled.
+#[inline]
+pub fn is_deterministic() -> bool {
+    DETERMINISTIC.load(Ordering::Relaxed)
+}
+
+/// Sets the seed to use for deterministic operations.
+/// Does **not** implicitly enable determinism.
+///
+/// Can only be called once.
+///
+/// # Panics
+///
+/// Panics when called more than once.
+#[inline]
+pub fn set_seed(seed: u64) {
+    DETERMINISTIC_SEED
+        .set(seed)
+        .expect("Seed can only be set once");
+}
+
+/// Returns the seed to use for random number generators.
+///
+/// `None` when no seed has been set yet.
+#[inline]
+#[cfg(not(test))]
+pub fn get_seed() -> Option<u64> {
+    DETERMINISTIC_SEED.get().copied()
+}
+
+#[inline]
+#[cfg(test)]
+pub fn get_seed() -> Option<u64> {
+    Some(42)
+}

--- a/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample_merger/similarity_merger.rs
+++ b/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample_merger/similarity_merger.rs
@@ -3,7 +3,7 @@ use super::super::t_iterator::TInteractionIter;
 use super::{Config, Sample};
 use super::{OrMerger, SampleMerger};
 use crate::int_hash::IntSet;
-use crate::util::rng;
+use crate::rand::rng;
 use rand::prelude::SliceRandom;
 use std::cmp::{Ordering, min};
 use streaming_iterator::StreamingIterator;

--- a/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample_merger/zipping_merger.rs
+++ b/ddnnife/src/ddnnf/anomalies/t_wise_sampling/sample_merger/zipping_merger.rs
@@ -5,7 +5,10 @@ use super::super::{
 use super::{AndMerger, SampleMerger};
 use super::{Config, Sample};
 use crate::Ddnnf;
+use crate::config;
 use crate::int_hash::IntSet;
+use crate::rand::rng;
+use rand::seq::SliceRandom;
 use std::cmp::min;
 use std::collections::HashSet;
 use streaming_iterator::StreamingIterator;
@@ -103,22 +106,16 @@ impl ZippingMerger<'_, '_> {
         });
 
         // Deterministic sampling requires the same iteration order between runs.
-        // As the HashSets used for the rest of the algorithm do not provide such a determinsitic order,
-        // we collect, sort and (determinsitically) shuffle the generated interactions.
-        #[cfg(feature = "deterministic")]
-        {
-            use crate::util::rng;
-            use rand::seq::SliceRandom;
-
+        // As the HashSets used for the rest of the algorithm do not provide such a deterministic order,
+        // we collect, sort and (deterministically) shuffle the generated interactions.
+        if config::is_deterministic() {
             let mut interactions: Vec<Vec<i32>> = interactions.into_iter().collect();
             interactions.sort_unstable();
             interactions.shuffle(&mut rng());
-
             interactions
+        } else {
+            interactions.into_iter().collect()
         }
-
-        #[cfg(not(feature = "deterministic"))]
-        interactions.into_iter().collect()
     }
 
     /// Generates a set of interactions inside a sample ordered by interactions size.

--- a/ddnnife/src/ddnnf/anomalies/t_wise_sampling/t_wise_sampler.rs
+++ b/ddnnife/src/ddnnf/anomalies/t_wise_sampling/t_wise_sampler.rs
@@ -5,7 +5,7 @@ use super::{Sample, SamplingResult, SatWrapper};
 use crate::NodeType;
 use crate::ddnnf::extended_ddnnf::ExtendedDdnnf;
 use crate::int_hash::{self, IntMap, IntSet};
-use crate::util::rng;
+use crate::rand::rng;
 use crate::{Ddnnf, DdnnfKind};
 use itertools::Itertools;
 use rand::prelude::SliceRandom;

--- a/ddnnife/src/lib.rs
+++ b/ddnnife/src/lib.rs
@@ -1,10 +1,12 @@
+pub mod config;
+pub mod ddnnf;
 pub mod int_hash;
 pub mod parser;
+pub mod rand;
 pub mod util;
+
+pub use crate::ddnnf::{Ddnnf, DdnnfKind, node::*};
 pub use crate::parser::c2d_lexer;
 pub use crate::parser::d4_lexer;
-
-pub mod ddnnf;
-pub use crate::ddnnf::{Ddnnf, DdnnfKind, node::*};
 
 pub mod cnf;

--- a/ddnnife/src/rand.rs
+++ b/ddnnife/src/rand.rs
@@ -1,0 +1,29 @@
+use crate::config;
+use rand::{SeedableRng, rngs::SmallRng};
+use std::sync::{LazyLock, OnceLock, RwLock, RwLockWriteGuard};
+
+static RNG: LazyLock<RwLock<SmallRng>> = LazyLock::new(|| RwLock::new(SmallRng::from_os_rng()));
+static RNG_DETERMINISTIC: OnceLock<RwLock<SmallRng>> = OnceLock::new();
+
+/// Returns a handle to a random number generator.
+///
+/// Uses a small but **not** cryptographically safe RNG.
+///
+/// Depending on the corresponding [config] entries, a deterministic RNG
+/// as specified by the seed or an actually random RNG is used.
+#[inline]
+pub fn rng<'a>() -> RwLockWriteGuard<'a, SmallRng> {
+    if config::is_deterministic() {
+        RNG_DETERMINISTIC
+            .get_or_init(|| {
+                RwLock::new(SmallRng::seed_from_u64(
+                    config::get_seed()
+                        .expect("Using deterministic operations requires a seed to be set"),
+                ))
+            })
+            .write()
+            .unwrap()
+    } else {
+        RNG.write().unwrap()
+    }
+}

--- a/ddnnife/src/util.rs
+++ b/ddnnife/src/util.rs
@@ -1,8 +1,4 @@
-use rand::Rng;
 use std::iter;
-
-#[cfg(any(feature = "deterministic", test))]
-use rand::prelude::{SeedableRng, StdRng};
 
 pub fn format_vec_separated_by<T: ToString>(
     vals: impl Iterator<Item = T>,
@@ -25,18 +21,6 @@ where
     vals.map(|res| format_vec(res.into_iter()))
         .collect::<Vec<String>>()
         .join(";")
-}
-
-#[cfg(any(feature = "deterministic", test))]
-#[inline]
-pub fn rng() -> impl Rng {
-    StdRng::seed_from_u64(42)
-}
-
-#[cfg(not(any(feature = "deterministic", test)))]
-#[inline]
-pub fn rng() -> impl Rng {
-    rand::rng()
 }
 
 pub fn zip_assumptions_variables<'a>(

--- a/ddnnife_cli/Cargo.toml
+++ b/ddnnife_cli/Cargo.toml
@@ -11,9 +11,6 @@ workspace = ".."
 name = "ddnnife"
 path = "src/main.rs"
 
-[features]
-deterministic = ["ddnnife/deterministic"]
-
 [dependencies]
 clap = { workspace = true }
 csv = { workspace = true }

--- a/ddnnife_cli/src/main.rs
+++ b/ddnnife_cli/src/main.rs
@@ -3,6 +3,7 @@ mod stream;
 use crate::stream::{Query, handle_query, stream};
 use clap::{Parser, Subcommand};
 use ddnnife::DdnnfKind;
+use ddnnife::config;
 use ddnnife::ddnnf::Ddnnf;
 use ddnnife::ddnnf::anomalies::t_wise_sampling::Sample;
 use ddnnife::ddnnf::statistics::Statistics;
@@ -46,6 +47,10 @@ struct Args {
     /// Logging level for outputting warnings and other information.
     #[arg(short, long, default_value_t=log::LevelFilter::Info)]
     logging: log::LevelFilter,
+
+    /// Enable deterministic behavior for random operations using the given seed.
+    #[arg(long)]
+    seed: Option<u64>,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -222,12 +227,18 @@ enum Operation {
 }
 
 fn main() -> io::Result<()> {
-    // Parse the
+    // Parse the CLI arguments.
     let cli = Args::parse();
 
     pretty_env_logger::formatted_builder()
         .filter_level(cli.logging)
         .init();
+
+    // Enable deterministic mode when a seed is given.
+    if let Some(seed) = cli.seed {
+        config::set_seed(seed);
+        config::set_deterministic(true);
+    }
 
     let time = Instant::now();
 


### PR DESCRIPTION
Introduces Rust and CLI APIs to enable determinism and set a seed. Uses the same kind of RNG for both scenarios, `SmallRng`. This is not cryptographically safe but smaller and faster.

Closes #94