### PR TITLE
Replace `once_cell` with `std` Implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,6 @@ dependencies = [
  "log",
  "nom 8.0.0",
  "num",
- "once_cell",
  "petgraph",
  "rand",
  "rand_distr",

--- a/ddnnife/Cargo.toml
+++ b/ddnnife/Cargo.toml
@@ -17,7 +17,6 @@ itertools = "0.14"
 log = { workspace = true }
 nom = "8"
 num = { workspace = true }
-once_cell = "1"
 petgraph = "0.8"
 rand = "0.9"
 rand_distr = "0.5"

--- a/ddnnife/src/ddnnf/anomalies/config_creation.rs
+++ b/ddnnife/src/ddnnf/anomalies/config_creation.rs
@@ -1,23 +1,19 @@
-use std::{
-    cmp::min,
-    collections::HashMap,
-    sync::{Arc, Mutex},
-};
-
+use crate::Ddnnf;
+use crate::NodeType::*;
 use itertools::Itertools;
 use num::{BigInt, BigRational, ToPrimitive, Zero};
-use once_cell::sync::Lazy;
 use rand::SeedableRng;
 use rand::seq::SliceRandom;
 use rand_distr::{Binomial, Distribution, weighted::WeightedAliasIndex};
 use rand_pcg::{Lcg64Xsh32, Pcg32};
+use std::{
+    cmp::min,
+    collections::HashMap,
+    sync::{LazyLock, RwLock},
+};
 
-use crate::Ddnnf;
-use crate::NodeType::*;
-
-#[allow(clippy::type_complexity)]
-static ENUMERATION_CACHE: Lazy<Arc<Mutex<HashMap<Vec<i32>, usize>>>> =
-    Lazy::new(|| Arc::new(Mutex::new(HashMap::new())));
+static ENUMERATION_CACHE: LazyLock<RwLock<HashMap<Vec<i32>, usize>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
 
 impl Ddnnf {
     /// Creates satisfiable complete configurations for a d-DNNF and given assumptions.
@@ -43,7 +39,7 @@ impl Ddnnf {
         assumptions.sort_unstable_by_key(|f| f.abs());
 
         if self.execute_query(assumptions) > BigInt::ZERO {
-            let last_stop = match ENUMERATION_CACHE.lock().unwrap().get(assumptions) {
+            let last_stop = match ENUMERATION_CACHE.read().unwrap().get(assumptions) {
                 Some(&x) => x,
                 None => 0,
             };
@@ -59,7 +55,7 @@ impl Ddnnf {
                 sample.sort_unstable_by_key(|f| f.abs());
             }
 
-            ENUMERATION_CACHE.lock().unwrap().insert(
+            ENUMERATION_CACHE.write().unwrap().insert(
                 assumptions.to_vec(),
                 (min(self.rt(), BigInt::from(last_stop + amount)) % self.rt())
                     .to_usize()


### PR DESCRIPTION
The dependency on `once_cell` is not needed any more since the standard library implements its functionality.

Additionally replace a `Mutex` with `RwLock` since read / write usage is clearly separated.

Depends on #104