### PR TITLE
Replace macOS `libiconv` Dependency

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,11 +31,11 @@ jobs:
           - double: x86_64-linux
             runner: ubuntu-24.04
             flake: ddnnife-static
-          - double: x86_64-darwin
-            runner: macos-26-intel
-            flake: ddnnife
           - double: aarch64-darwin
             runner: macos-26
+            flake: ddnnife
+          - double: x86_64-darwin
+            runner: macos-26-intel
             flake: ddnnife
           - double: x86_64-windows
             runner: ubuntu-24.04
@@ -232,13 +232,13 @@ jobs:
             runner: ubuntu-24.04
             flake: python-static
           - double: x86_64-darwin
-            runner: macos-26-intel
-            flake: python
-            test: true
-          - double: aarch64-darwin
-            runner: macos-26
-            flake: python
-            test: true
+          #   runner: macos-26-intel
+          #   flake: python
+          #   test: true
+          # - double: aarch64-darwin
+          #   runner: macos-26
+          #   flake: python
+          #   test: true
           - double: x86_64-windows
             runner: ubuntu-24.04
             flake: python-windows

--- a/nix/ddnnife.nix
+++ b/nix/ddnnife.nix
@@ -11,6 +11,7 @@
   crane,
   fenix,
   lib,
+  libiconv,
   pkgs,
   cranePkgs ? null,
   stdenv,
@@ -131,6 +132,29 @@ craneLib.${craneAction} (
   // lib.optionalAttrs dynamicMusl {
     CARGO_BUILD_RUSTFLAGS = "-C target-feature=-crt-static";
   }
+  # On macOS, replace the link to Nix' libiconv to point to the system provided one.
+  //
+    lib.optionalAttrs
+      (
+        stdenv.buildPlatform.isDarwin
+        && builtins.elem component [
+          "ddnnife_cli"
+          "ddnnife_ffi"
+        ]
+      )
+      (
+        let
+          fileToPatch =
+            {
+              ddnnife_cli = "$out/bin/ddnnife";
+              ddnnife_ffi = "$out/lib/libddnnife.dylib";
+            }
+            .${component};
+        in
+        {
+          postInstall = "install_name_tool -change ${libiconv}/lib/libiconv.2.dylib /usr/lib/libiconv.2.dylib ${fileToPatch}";
+        }
+      )
   // lib.optionalAttrs benchmark {
     pname = "${name}-bench";
     cargoTestCommand = "cargo bench > benchmark.txt";


### PR DESCRIPTION
Replaces the `libiconv` instance linked against on macOS to point to the system provided one in order to allow running the binary or library without the Nix provided `libiconv` present.

The original issue still persists with the Python build as it is built independently of the library build. This has to be fixed separately.