### PR TITLE
FFI: Expose Configuration

### DIFF
--- a/bindings/kotlin/src/main/kotlin/de/softvare/ddnnife/java-utils.kt
+++ b/bindings/kotlin/src/main/kotlin/de/softvare/ddnnife/java-utils.kt
@@ -75,3 +75,28 @@ fun getSample(result: SamplingResult): Sample {
         }
     }
 }
+
+class DdnnifeConfig {
+    companion object {
+        @JvmStatic
+        fun setDeterministic(enable: Boolean) {
+            return de.softvare.ddnnife.setDeterministic(enable)
+        }
+
+        @JvmStatic
+        fun isDeterministic(): Boolean {
+            return de.softvare.ddnnife.isDeterministic()
+        }
+
+        @JvmStatic
+        fun setSeed(seed: Long) {
+            require(seed >= 0) { "Seed must be positive." }
+            return de.softvare.ddnnife.setSeed(seed.toULong())
+        }
+
+        @JvmStatic
+        fun getSeed(): Long? {
+            return de.softvare.ddnnife.getSeed()?.toLong()
+        }
+    }
+}

--- a/bindings/kotlin/src/test/java/de/softvare/ddnnife/JavaTest.java
+++ b/bindings/kotlin/src/test/java/de/softvare/ddnnife/JavaTest.java
@@ -17,6 +17,17 @@ class JavaTest {
     private final Integer features = 854;
 
     @Test
+    void config() {
+        if (DdnnifeConfig.getSeed() == null) {
+            DdnnifeConfig.setSeed(42);
+            assertEquals(42, DdnnifeConfig.getSeed());
+        }
+
+        DdnnifeConfig.setDeterministic(true);
+        assertTrue(DdnnifeConfig.isDeterministic());
+    }
+
+    @Test
     void sat() {
         DdnnfMut ddnnfMut = ddnnf.asMut();
         assertTrue(ddnnfMut.isSat(emptyList()));

--- a/bindings/kotlin/src/test/kotlin/de/softvare/ddnnife/DdnnfTest.kt
+++ b/bindings/kotlin/src/test/kotlin/de/softvare/ddnnife/DdnnfTest.kt
@@ -3,11 +3,23 @@ package de.softvare.ddnnife
 import java.math.BigInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.fail
 
 internal class DdnnfTest {
     private val ddnnf = Ddnnf.fromFile("../../example_input/busybox-1.18.0_c2d.nnf", null)
     private val features = 854
+
+    @Test
+    fun config() {
+        if (getSeed() == null) {
+            setSeed(42U)
+            assertEquals(42U, getSeed())
+        }
+
+        setDeterministic(true)
+        assert(isDeterministic())
+    }
 
     @Test
     fun sat() {
@@ -66,11 +78,12 @@ internal class DdnnfTest {
     @Test
     fun tWise() {
         val result = ddnnf.sampleTWise(1u, null)
-        when(result) {
+        when (result) {
             is SamplingResult.ResultWithSample -> {
                 val sample = result.v1
                 assertEquals(features, sample.vars.size)
             }
+
             else -> {
                 fail("T-wise sample is invalid.")
             }
@@ -88,12 +101,12 @@ internal class DdnnfTest {
 
     @Test
     fun trivial() {
-      val trivialDdnnf = Ddnnf.fromFile("../../ddnnife/tests/data/stub_true.nnf", null)
-      assert(trivialDdnnf.isTrivial())
+        val trivialDdnnf = Ddnnf.fromFile("../../ddnnife/tests/data/stub_true.nnf", null)
+        assert(trivialDdnnf.isTrivial())
     }
 
     @Test
     fun nonTrivial() {
-      assert(!ddnnf.isTrivial())
+        assert(!ddnnf.isTrivial())
     }
 }

--- a/ddnnife_ffi/src/config.rs
+++ b/ddnnife_ffi/src/config.rs
@@ -1,0 +1,36 @@
+use ddnnife::config;
+
+/// Enables or disables deterministic operations.
+///
+/// Actually using deterministic operations requires a seed to be set.
+#[uniffi::export]
+pub fn set_deterministic(enable: bool) {
+    config::set_deterministic(enable);
+}
+
+/// Returns whether deterministic mode is currently enabled.
+#[uniffi::export]
+pub fn is_deterministic() -> bool {
+    config::is_deterministic()
+}
+
+/// Sets the seed to use for deterministic operations.
+/// Does **not** implicitly enable determinism.
+///
+/// Can only be called once.
+///
+/// # Panics
+///
+/// Panics when called more than once.
+#[uniffi::export]
+pub fn set_seed(seed: u64) {
+    config::set_seed(seed);
+}
+
+/// Returns the seed to use for random number generators.
+///
+/// Not valid when no seed has been set yet.
+#[uniffi::export]
+pub fn get_seed() -> Option<u64> {
+    config::get_seed()
+}

--- a/ddnnife_ffi/src/lib.rs
+++ b/ddnnife_ffi/src/lib.rs
@@ -1,6 +1,7 @@
 uniffi::setup_scaffolding!();
 
 mod cnf;
+mod config;
 mod ddnnf;
 mod ddnnf_mut;
 mod statistics;


### PR DESCRIPTION
Exposes the library-wide configuration to Kotlin and Python. Currently only covers determinism.

Closes #125 