### PR TITLE
Make Parser Deterministic

### DIFF
--- a/ddnnife/benches/load.rs
+++ b/ddnnife/benches/load.rs
@@ -1,35 +1,31 @@
-use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, SamplingMode, criterion_group, criterion_main};
 use ddnnife::Ddnnf;
-use std::hint::black_box;
-use std::path::Path;
+use std::{hint::black_box, path::Path};
 
-fn small_c2d(c: &mut Criterion) {
-    let path = Path::new("../example_input/small_example_c2d.nnf");
-    c.bench_function("load small (c2d)", |b| {
-        b.iter(|| Ddnnf::from_file(black_box(path), None))
-    });
+static BENCHMARKS: [(&str, &str); 6] = [
+    ("auto1_d4.nnf", "auto1 (d4)"),
+    ("auto2_c2d.nnf", "auto2 (c2d)"),
+    ("axTLS_d4.nnf", "axTLS (d4)"),
+    ("busybox_c2d.nnf", "BusyBox (c2d)"),
+    ("VP9_d4.nnf", "VP9 (d4)"),
+    ("X264_c2d.nnf", "X264 (c2d)"),
+];
+
+fn benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("load");
+    group.sampling_mode(SamplingMode::Flat);
+
+    let data_dir = Path::new("tests/data");
+
+    for (path, name) in BENCHMARKS {
+        let path = &data_dir.join(path);
+        group.bench_function(name, |bencher| {
+            bencher.iter(|| Ddnnf::from_file(black_box(path), None))
+        });
+    }
+
+    group.finish();
 }
 
-fn busybox_c2d(c: &mut Criterion) {
-    let path = Path::new("../example_input/busybox-1.18.0_c2d.nnf");
-    c.bench_function("load busybox (c2d)", |b| {
-        b.iter(|| Ddnnf::from_file(black_box(path), None))
-    });
-}
-
-fn auto1_d4(c: &mut Criterion) {
-    let path = Path::new("../example_input/auto1_d4_2513.nnf");
-    c.bench_function("load auto1 (d4)", |b| {
-        b.iter(|| Ddnnf::from_file(black_box(path), None))
-    });
-}
-
-fn auto2_c2d(c: &mut Criterion) {
-    let path = Path::new("../example_input/auto2_4_c2d.nnf");
-    c.bench_function("load auto2 (c2d)", |b| {
-        b.iter(|| Ddnnf::from_file(black_box(path), None))
-    });
-}
-
-criterion_group!(benches, small_c2d, busybox_c2d, auto1_d4, auto2_c2d);
+criterion_group!(benches, benchmark);
 criterion_main!(benches);

--- a/ddnnife/src/ddnnf.rs
+++ b/ddnnife/src/ddnnf.rs
@@ -5,12 +5,13 @@ pub mod multiple_queries;
 pub mod node;
 pub mod statistics;
 
-use self::node::Node;
 use crate::NodeType;
+use crate::int_hash::IntMap;
 use crate::parser::graph::{DdnnfGraph, rebuild_graph};
+use node::Node;
 use num::BigInt;
 use petgraph::stable_graph::NodeIndex;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::path::Path;
 
@@ -34,7 +35,7 @@ pub struct Ddnnf {
     /// The actual nodes of the d-DNNF in postorder
     pub nodes: Vec<Node>,
     /// Literals for upwards propagation
-    pub literals: HashMap<i32, usize>, // <var_number of the Literal, and the corresponding indize>
+    pub literals: IntMap<i32, usize>, // <var_number of the Literal, and the corresponding indize>
     /// The core/dead features of the model corresponding with this ddnnf
     pub core: HashSet<i32>,
     /// An interim save for the marking algorithm

--- a/ddnnife/src/int_hash.rs
+++ b/ddnnife/src/int_hash.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::hash::{BuildHasher, Hash, Hasher};
 
+static SEED: u64 = 0x9E3779B97F4A7C15;
+
 /// Creates a new `IntMap` with capacity reserved for the given number of elements.
 pub fn map_with_capacity<K, V>(capacity: usize) -> IntMap<K, V>
 where
@@ -11,19 +13,27 @@ where
     map
 }
 
-/// A `HashMap` not doing any hashing but using keys as-is.
+/// A `HashMap` using deterministic hashing.
 pub type IntMap<K, V> = HashMap<K, V, BuildIntHasher>;
 
-/// A `HashSet` not doing any hashing but using keys as-is.
+/// A `HashSet` using deterministic hashing.
 pub type IntSet<K> = HashSet<K, BuildIntHasher>;
 
 /// A hasher for integer maps and sets.
 ///
-/// Does not do any hashing but instead returns input values as-is.
+/// Does not actually do any hashing, but spreads the inputs using a fixed seed.
 /// Currently only accepts `usize`, `u32` and `i32`.
 #[derive(Default)]
 pub struct IntHasher {
     hash: u64,
+}
+
+impl IntHasher {
+    /// Spreads inputs using a fixed seed in order to avoid hash collisions
+    /// when using many sequential inputs.
+    fn hash(&mut self, input: u64) {
+        self.hash = input ^ SEED;
+    }
 }
 
 impl Hasher for IntHasher {
@@ -32,15 +42,15 @@ impl Hasher for IntHasher {
     }
 
     fn write_usize(&mut self, input: usize) {
-        self.hash = input as u64;
+        self.hash(input as u64);
     }
 
     fn write_u32(&mut self, input: u32) {
-        self.hash = input as u64;
+        self.hash(input as u64);
     }
 
     fn write_i32(&mut self, input: i32) {
-        self.hash = input as u64;
+        self.hash(input as u64);
     }
 
     fn finish(&self) -> u64 {

--- a/ddnnife/src/int_hash.rs
+++ b/ddnnife/src/int_hash.rs
@@ -62,8 +62,38 @@ impl BuildHasher for BuildIntHasher {
 
 #[cfg(test)]
 mod tests {
+    use petgraph::graph::NodeIndex;
+
     use super::{IntHasher, IntMap, IntSet};
     use std::hash::{Hash, Hasher};
+
+    #[test]
+    fn can_hash_u32() {
+        let mut hasher = IntHasher::default();
+        let input: u32 = 42;
+        input.hash(&mut hasher);
+    }
+
+    #[test]
+    fn can_hash_i32() {
+        let mut hasher = IntHasher::default();
+        let input: i32 = -42;
+        input.hash(&mut hasher);
+    }
+
+    #[test]
+    fn can_hash_usize() {
+        let mut hasher = IntHasher::default();
+        let input: usize = 42;
+        input.hash(&mut hasher);
+    }
+
+    #[test]
+    fn can_hash_node_index() {
+        let mut hasher = IntHasher::default();
+        let input: NodeIndex = NodeIndex::new(42);
+        input.hash(&mut hasher);
+    }
 
     #[test]
     fn deterministic_same() {
@@ -116,11 +146,13 @@ mod tests {
         a.insert(3);
         a.insert(1);
         a.insert(2);
+        a.insert(-42);
 
         let mut b = IntSet::default();
         b.insert(3);
         b.insert(1);
         b.insert(2);
+        b.insert(-42);
 
         let a_vec: Vec<i32> = a.into_iter().collect();
         let b_vec: Vec<i32> = b.into_iter().collect();

--- a/ddnnife/src/parser.rs
+++ b/ddnnife/src/parser.rs
@@ -5,7 +5,10 @@ pub mod graph;
 pub mod persisting;
 pub mod util;
 
-use crate::ddnnf::{Ddnnf, extended_ddnnf::Attribute, node::Node};
+use crate::{
+    ddnnf::{Ddnnf, extended_ddnnf::Attribute, node::Node},
+    int_hash::{IntMap, IntSet},
+};
 use c2d_lexer::{C2DToken, TId, lex_line_c2d};
 use core::panic;
 use csv::ReaderBuilder;
@@ -24,7 +27,7 @@ use std::cell::RefMut;
 use std::{
     cell::RefCell,
     cmp::max,
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fs::File,
     io::{BufRead, BufReader},
     path::Path,
@@ -119,7 +122,7 @@ pub fn distribute_building(lines: Vec<String>, total_features: Option<u32>) -> D
 fn build_c2d_ddnnf(lines: Vec<String>, variables: u32) -> Ddnnf {
     let mut ddnnf_graph = DdnnfGraph::new();
     let mut node_indices = Vec::with_capacity(lines.len());
-    let mut literals_nx: HashMap<i32, NodeIndex> = HashMap::new();
+    let mut literals_nx: IntMap<i32, NodeIndex> = IntMap::default();
 
     // opens the file with a BufReader and
     // works off each line of the file data seperatly
@@ -176,7 +179,7 @@ fn build_d4_ddnnf(lines: Vec<String>, total_features_opt: Option<u32>) -> Ddnnf 
 
     // With the help of the literals node state, we can add the required nodes
     // for the balancing of the or nodes to archieve smoothness
-    let literals_nx: Rc<RefCell<HashMap<i32, NodeIndex>>> = Rc::new(RefCell::new(HashMap::new()));
+    let literals_nx: Rc<RefCell<IntMap<i32, NodeIndex>>> = Rc::new(RefCell::new(IntMap::default()));
 
     // while parsing:
     // remove the weighted edges and substitute it with the corresponding
@@ -311,7 +314,7 @@ fn build_d4_ddnnf(lines: Vec<String>, total_features_opt: Option<u32>) -> Ddnnf 
     //                                         /  \  /
     //                                       -Lm   Lm
     //
-    let mut literal_diff: HashMap<NodeIndex, HashSet<i32>> = get_literal_diffs(&ddnnf_graph, root);
+    let mut literal_diff: IntMap<NodeIndex, IntSet<i32>> = get_literal_diffs(&ddnnf_graph, root);
     let mut dfs = DfsPostOrder::new(&ddnnf_graph, root);
 
     while let Some(nx) = dfs.next(&ddnnf_graph) {
@@ -323,7 +326,7 @@ fn build_d4_ddnnf(lines: Vec<String>, total_features_opt: Option<u32>) -> Ddnnf 
                 .map(|c| {
                     (
                         c,
-                        HashSet::from_iter(
+                        IntSet::from_iter(
                             literal_diff
                                 .get(&c)
                                 .unwrap()
@@ -353,7 +356,7 @@ fn build_d4_ddnnf(lines: Vec<String>, total_features_opt: Option<u32>) -> Ddnnf 
 fn get_literal_indices(
     ddnnf_graph: &mut StableGraph<TId, ()>,
     literals: Vec<i32>,
-    lit_nx: &mut RefMut<HashMap<i32, NodeIndex>>,
+    lit_nx: &mut RefMut<IntMap<i32, NodeIndex>>,
 ) -> Vec<NodeIndex> {
     let mut literal_nodes = Vec::new();
 
@@ -404,8 +407,8 @@ fn delete_chain(ddnnf_graph: &mut DdnnfGraph, start: NodeIndex, replacement: TId
 fn balance_or_children(
     ddnnf_graph: &mut DdnnfGraph,
     from: NodeIndex,
-    children: Vec<(NodeIndex, HashSet<u32>)>,
-    lit_nx: &mut RefMut<HashMap<i32, NodeIndex>>,
+    children: Vec<(NodeIndex, IntSet<u32>)>,
+    lit_nx: &mut RefMut<IntMap<i32, NodeIndex>>,
     total_features: u32,
 ) {
     for (child_nx, child_literals) in children {
@@ -426,7 +429,7 @@ fn add_literal_node(
     ddnnf_graph: &mut DdnnfGraph,
     f_u32: u32,
     attach: NodeIndex,
-    lit_nx: &mut RefMut<HashMap<i32, NodeIndex>>,
+    lit_nx: &mut RefMut<IntMap<i32, NodeIndex>>,
     total_features: u32,
 ) {
     let or_triangles: Rc<RefCell<Vec<Option<NodeIndex>>>> =
@@ -451,10 +454,10 @@ fn add_literal_node(
 }
 
 // Computes the difference between the children of a Node
-fn diff(literals: Vec<(NodeIndex, HashSet<u32>)>) -> Vec<(NodeIndex, HashSet<u32>)> {
-    let mut res: Vec<(NodeIndex, HashSet<u32>)> = Vec::new();
+fn diff(literals: Vec<(NodeIndex, IntSet<u32>)>) -> Vec<(NodeIndex, IntSet<u32>)> {
+    let mut res: Vec<(NodeIndex, IntSet<u32>)> = Vec::new();
     for i in 0..literals.len() {
-        let mut val: HashSet<u32> = HashSet::default();
+        let mut val: IntSet<u32> = IntSet::default();
         for (j, i_res) in literals.iter().enumerate() {
             if i != j {
                 val.extend(i_res.1.clone());
@@ -469,11 +472,8 @@ fn diff(literals: Vec<(NodeIndex, HashSet<u32>)>) -> Vec<(NodeIndex, HashSet<u32
 }
 
 /// Computes the combined literals used in its children
-pub fn get_literal_diffs(
-    di_graph: &DdnnfGraph,
-    root: NodeIndex,
-) -> HashMap<NodeIndex, HashSet<i32>> {
-    let mut safe: HashMap<NodeIndex, HashSet<i32>> = HashMap::new();
+pub fn get_literal_diffs(di_graph: &DdnnfGraph, root: NodeIndex) -> IntMap<NodeIndex, IntSet<i32>> {
+    let mut safe: IntMap<NodeIndex, IntSet<i32>> = IntMap::default();
     let mut dfs = DfsPostOrder::new(di_graph, root);
     while let Some(nx) = dfs.next(di_graph) {
         get_literals(di_graph, &mut safe, nx);
@@ -484,7 +484,7 @@ pub fn get_literal_diffs(
 /// Computes the combined literals used in its children
 pub fn extend_literal_diffs(
     di_graph: &DdnnfGraph,
-    current_safe: &mut HashMap<NodeIndex, HashSet<i32>>,
+    current_safe: &mut IntMap<NodeIndex, IntSet<i32>>,
     root: NodeIndex,
 ) {
     let mut dfs = DfsPostOrder::new(di_graph, root);
@@ -498,16 +498,16 @@ pub fn extend_literal_diffs(
 // determine what literal-nodes the current node is or which occur in its children
 fn get_literals(
     di_graph: &DdnnfGraph,
-    safe: &mut HashMap<NodeIndex, HashSet<i32>>,
+    safe: &mut IntMap<NodeIndex, IntSet<i32>>,
     deciding_node_child: NodeIndex,
-) -> HashSet<i32> {
+) -> IntSet<i32> {
     let lookup = safe.get(&deciding_node_child);
     if let Some(x) = lookup {
         return x.clone();
     }
 
     use c2d_lexer::TokenIdentifier::*;
-    let mut res = HashSet::new();
+    let mut res = IntSet::default();
     match di_graph[deciding_node_child] {
         And | Or => {
             di_graph

--- a/ddnnife/src/parser/graph.rs
+++ b/ddnnife/src/parser/graph.rs
@@ -1,21 +1,21 @@
 use super::{calc_and_count, calc_or_count};
 use crate::c2d_lexer::TId;
+use crate::int_hash::IntMap;
 use crate::{DdnnfKind, Node, NodeType};
 use petgraph::algo::is_cyclic_directed;
 use petgraph::prelude::DfsPostOrder;
 use petgraph::stable_graph::{NodeIndex, StableGraph};
-use std::collections::HashMap;
 
 pub type DdnnfGraph = StableGraph<TId, ()>;
 
 pub fn rebuild_graph(
     graph: DdnnfGraph,
     root: NodeIndex,
-) -> (DdnnfKind, Vec<Node>, HashMap<i32, usize>) {
+) -> (DdnnfKind, Vec<Node>, IntMap<i32, usize>) {
     // Check for special cases where there is a boolean root node.
     match graph[root] {
-        TId::True => return (DdnnfKind::Tautology, Vec::new(), HashMap::new()),
-        TId::False => return (DdnnfKind::Contradiction, Vec::new(), HashMap::new()),
+        TId::True => return (DdnnfKind::Tautology, Vec::new(), IntMap::default()),
+        TId::False => return (DdnnfKind::Contradiction, Vec::new(), IntMap::default()),
         _ => {}
     }
 
@@ -26,10 +26,10 @@ pub fn rebuild_graph(
     // that child nodes are listed before their parents
     // transform that interim representation into a node vector
     let mut dfs = DfsPostOrder::new(&graph, root);
-    let mut nd_to_usize: HashMap<NodeIndex, usize> = HashMap::new();
+    let mut nd_to_usize: IntMap<NodeIndex, usize> = IntMap::default();
 
     let mut parsed_nodes: Vec<Node> = Vec::with_capacity(graph.node_count());
-    let mut literals: HashMap<i32, usize> = HashMap::new();
+    let mut literals: IntMap<i32, usize> = IntMap::default();
 
     while let Some(nx) = dfs.next(&graph) {
         nd_to_usize.insert(nx, parsed_nodes.len());


### PR DESCRIPTION
Use `IntSet` and `IntMap` when building sets/maps of integer keys to build the same data structure for one input.

Improves the hash function used by `IntSet` and `IntMap` to better spread the resulting hash values.

Closes #134 